### PR TITLE
chore: add .omc/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Cargo.lock
 /target
 
 lcov.info
+
+# oh-my-claudecode scratch
+.omc/


### PR DESCRIPTION
**Note:** This MR was largely generated by Claude and has not been completely reviewed by me (the human). You should feel free to defer your review until this warning has been removed.

## Summary
Adds `.omc/` to `.gitignore` so the oh-my-claudecode scratch directory does not show up as untracked when working in this repo.

Part of a baseline-settings pass across all active `jdidion/*` repos.