### PR TITLE
fix: satisfy mismatched_lifetime_syntaxes in spawn_results

### DIFF
--- a/src/hive/inner/shared.rs
+++ b/src/hive/inner/shared.rs
@@ -143,7 +143,7 @@ impl<W: Worker, Q: Queen<Kind = W>, T: TaskQueues<Q::Kind>> Shared<Q, T> {
     }
 
     /// Returns the mutex guard for the results of spawing worker threads.
-    pub fn spawn_results(&self) -> MutexGuard<Vec<Result<JoinHandle<()>, SpawnError>>> {
+    pub fn spawn_results(&self) -> MutexGuard<'_, Vec<Result<JoinHandle<()>, SpawnError>>> {
         self.spawn_results.lock()
     }
 


### PR DESCRIPTION
**Note:** This MR was largely generated by Claude and has not been completely reviewed by me (the human). You should feel free to defer your review until this warning has been removed.

## Summary
Fixes a pre-existing clippy failure on `main` from the newer `mismatched_lifetime_syntaxes` lint. `SharedInner::spawn_results` returns `MutexGuard<T>` where `&self` provides an elided lifetime — the explicit `MutexGuard<'_, T>` form resolves the lint.

This unblocks the template-alignment PR (#12) which was inheriting the same red CI.

## Test plan
- [x] `cargo clippy --all-targets -F affinity,local-batch,retry -- -D warnings` passes locally.
- [ ] CI clippy job passes.